### PR TITLE
Change command line option "--with-slurm" to "--scheduler slurm"

### DIFF
--- a/coltune_script.py
+++ b/coltune_script.py
@@ -89,7 +89,7 @@ def main():
                 print("", file=f)
 
         f.close()
-        print("SGE script wrote to "+collective+"_coltune.sh successfully!")
+        print("Creating jobscript %s_coltune.sh ... success!" % collective)
 
 if __name__ == "__main__":
     main()

--- a/run_and_analyze.sh
+++ b/run_and_analyze.sh
@@ -11,25 +11,28 @@
 
 numcoll=0
 config_file=""
-with_slurm=false
+scheduler="SGE"
 
 usage()
 {
-	echo "Usage:
-		$0
-		   -c | --config-file <config>
-		   --with-slurm
+    echo "Usage:
+        $0
+           -c | --config-file <config>
+           --scheduler (SGE|slurm)
 Options:
-		   --config-file (string)
-			The file containing global configurations.
-		   --with-slurm
-			Use slurm instead of the default SGE." 1>&2; exit 1;
+           -h,--help
+            Print help message
+           --config-file (string)
+            The file containing global configurations.
+           --scheduler (string)
+            Specify scheduler to use, available options are SGE,slurm (default SGE." 1>&2; exit 1;
 
 }
 
-OPTIONS=$(getopt -o :c: --long with-slurm,config-file: -- "$@")
+OPTIONS=$(getopt -o :c:h -l help,scheduler:,config-file: -- "$@")
 
 if [[ $? -ne 0 ]]; then
+        echo "Command line error"
         usage
         exit 1
 fi
@@ -37,55 +40,63 @@ fi
 eval set -- "$OPTIONS"
 while true; do
         case "$1" in
-                '-c'|'--config-file')
-                        case "$2" in
-				"") shift 2 ;;
-				*) config_file=$2; shift 2 ;;
-			esac
-			;;
-		'--with-slurm')
-			with_slurm=true
-			shift
-			;;
+            '-h'|'--help') usage; exit 0 ;;
+            '-c'|'--config-file')
+                case "$2" in
+                    "") shift 2 ;;
+                    *) config_file=$2; shift 2 ;;
+                esac
+            ;;
+            '--scheduler')
+                case "$2" in
+                    "") shift 2 ;;
+                    *) scheduler=$2; shift 2 ;;
+                esac
+            ;;
                 '--')
                         shift
                         break
-			;;
+            ;;
                 *) echo "Internal error!"; usage; exit 1 ;;
-	esac
+    esac
 done
 
 if [ "$config_file" = "" ]; then
-	usage
-	exit 1
+    echo "Error: No config file specified."
+    usage
+    exit 1
 fi
 
 collectives=$(cat $config_file | grep "collectives")
 collectives=$(cut -d ":" -f 2 <<< "$collectives")
-work_dir=$(dirname "$0")
+work_dir=$(realpath $(dirname "$0"))
 
-if [ $with_slurm = true ]; then
-	python coltune_script.py $config_file slurm
-	if [ $? -ne 0 ]; then
-		echo "Failed to create job scripts. Exiting.."
-		exit 1;
-	fi
-	for collective in ${collectives// / } ; do
-		sbatch -W $work_dir/output/$collective/${collective}_coltune.sh
-	done
-	python coltune_analyze.py $config_file
-else
-	python coltune_script.py $config_file sge
-	if [ $? -ne 0 ]; then
-		echo "Failed to create job scripts. Exiting.."
-		exit 1;
-	fi
+case "$scheduler" in
+    "slurm")
+        python coltune_script.py $config_file slurm
+        if [ $? -ne 0 ]; then
+            echo "Failed to create job scripts. Exiting.."
+            exit 1;
+        fi
+        for collective in ${collectives// / } ; do
+            sbatch -W $work_dir/output/$collective/${collective}_coltune.sh
+        done
+        python coltune_analyze.py $config_file
+    ;;
+    "SGE")
+        python coltune_script.py $config_file sge
+        if [ $? -ne 0 ]; then
+            echo "Failed to create job scripts. Exiting.."
+            exit 1;
+        fi
 
-	for collective in ${collectives// / } ; do
-		qsub -N $collective -cwd $work_dir/output/$collective/${collective}_coltune.sh
-	done
-	collective_string=$(echo $collectives | sed 's/ /,/g')
-	qsub -hold_jid $collective_string $work_dir/analyze.sh -c $config_file
-fi
+        for collective in ${collectives// / } ; do
+            qsub -N $collective -cwd $work_dir/output/$collective/${collective}_coltune.sh
+        done
+        collective_string=$(echo $collectives | sed 's/ /,/g')
+        qsub -hold_jid $collective_string $work_dir/analyze.sh -c $config_file
+    ;;
+    *) echo "Error: Unknown scheduler '$scheduler'."; usage; exit 1 ;;
+esac
 
 exit


### PR DESCRIPTION
Adapt collective tuning scripts so it is possible to add more schedulers

Replaced --with-slurm option of run_and_analyze.sh script with
more general --scheduler option to allow more sheduler targets.