### PR TITLE
Allow colons as part of option values

### DIFF
--- a/common.py
+++ b/common.py
@@ -16,7 +16,7 @@ class Params:
         l = f.readline()
         while len(l):
             if l[0]!='#':
-                itmlst = l.split( ":")
+                itmlst = l.split( ":", 1)
                 if len(itmlst)==2:
                     self.m_params[itmlst[0].strip()] = itmlst[1].strip()
 


### PR DESCRIPTION
Entire lines in the config file were split using the colon as separator, so a colon could not be used inside values.
