### PR TITLE
Config mpirun options

### DIFF
--- a/coltune_script.py
+++ b/coltune_script.py
@@ -30,6 +30,7 @@ def main():
     max_num_node = config.getInt("max_num_node")
     num_core_per_node = config.getInt("number_of_cores_per_node")
     num_run = config.getInt("number_of_runs_per_test")
+    mpirun_options = config.getStr("mpirun_options")
 
     job_directory = dir_path+"/collective_jobs"
     for collective in collective_list:
@@ -82,6 +83,7 @@ def main():
                     else:
                         prg_name = omb_path+"/osu_"+collective
                     cmd = "mpirun --np %d " % (num_rank)
+                    cmd += "%s " % (mpirun_options)
                     cmd += "--mca coll_tuned_use_dynamic_rules 1 --mca coll_tuned_"+collective+"_algorithm "+str(alg)
                     cmd += " " + prg_name
                     cmd += " >& " + dir_path+"/output/"+collective + "/" + str(alg) + "_" + str(num_rank) + "ranks" + "_run" + str(run_id) + ".out"

--- a/common.py
+++ b/common.py
@@ -16,7 +16,7 @@ class Params:
         l = f.readline()
         while len(l):
             if l[0]!='#':
-                itmlst = l.split( ":")
+                itmlst = l.split( ":", 1)
                 if len(itmlst)==2:
                     self.m_params[itmlst[0].strip()] = itmlst[1].strip()
 

--- a/example/config-one-proc-per-node
+++ b/example/config-one-proc-per-node
@@ -1,8 +1,8 @@
 collectives : allgather allgatherv allreduce alltoall alltoallv barrier bcast gather reduce reduce_scatter_block reduce_scatter scatter
 omb_collective_directory : /path/to/install/libexec/osu-micro-benchmarks/mpi/collective/
 imb_binary : /path/to/install/IMB-MPI1
-number_of_ranks : 2 4 8 16 32 64
-max_num_node : 2
-number_of_cores_per_node : 36
+number_of_ranks : 2 3 4 5 6 7 8
+max_num_node : 8
+number_of_cores_per_node : 1
 number_of_runs_per_test : 3
-mpirun_options :
+mpirun_options : --map-by ppr:1:node


### PR DESCRIPTION
Add new option "mpirun_options" to config file to address #13 

This requires #15 to be merged first

With the addition of "mpirun_options" to the config file it is easy to
run specific mapping and pinning configurations.
An example for mapping one process per node is provided.